### PR TITLE
feat(ci): Add a shared setup workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,40 +6,13 @@ on:
     tags:
       - v*
 
-env:
-  DEFAULT_TAG_VERSION: "latest"
-  BUILD_PLATFORMS: "linux/amd64,linux/arm64"
-  IMAGE_REGISTRY: "ghcr.io"
-
 jobs:
   setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Workflow Variables
-        id: set-variables
-        run: |
-          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
-          echo "IMAGE_REPOSITORY=${{ env.IMAGE_REGISTRY}}/$GITHUB_REPOSITORY" >> $GITHUB_OUTPUT
-
-          # Set versions based on presence of tag
-          if [[ "${{ github.ref }}" =~ ^refs/tags/ ]]; then
-            echo "IMAGE_TAG=$(echo ${GITHUB_REF/refs\/tags\//})" >> $GITHUB_OUTPUT
-          else
-            echo "IMAGE_TAG=${DEFAULT_TAG_VERSION}" >> $GITHUB_OUTPUT
-          fi
-
-          # Create Distribution Matrix
-          echo "DIST_MATRIX=$(echo -n "$BUILD_PLATFORMS" | jq -csR '. | split(",")')" >> $GITHUB_OUTPUT
-          # Create Image Tags
-          echo "IMAGE_PLATFORM_TAGS=$(echo $BUILD_PLATFORMS | sed  -e 's/,/ /g' -e 's/\//-/g')" >> $GITHUB_OUTPUT
-
-    outputs:
-      repository_name: ${{ steps.set-variables.outputs.REPOSITORY_NAME }}
-      image_repository: ${{ steps.set-variables.outputs.IMAGE_REPOSITORY }}
-      image_tag: ${{ steps.set-variables.outputs.IMAGE_TAG}}
-      dist_matrix: ${{ steps.set-variables.outputs.DIST_MATRIX }}
-      image_platform_tags: ${{ steps.set-variables.outputs.IMAGE_PLATFORM_TAGS }}
-
+    uses: ./.github/workflows/setup.yaml
+    with:
+      default_tag_version: "latest"
+      build_platforms: "linux/amd64,linux/arm64"
+      image_registry: "ghcr.io"
 
   build:
     runs-on: ubuntu-latest
@@ -66,7 +39,7 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a #pin@v2.1.0
         with:
-          registry: ${{ env.IMAGE_REGISTRY }}
+          registry: ${{ needs.setup.outputs.image_registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -95,7 +68,6 @@ jobs:
             ${{ needs.setup.outputs.image_repository }}:latest-${{ steps.set-build-variables.outputs.PLATFORM_OS }}-${{ steps.set-build-variables.outputs.PLATFORM_ARCH }}
             ${{ needs.setup.outputs.image_repository }}:${{ needs.setup.outputs.image_tag }}-${{ steps.set-build-variables.outputs.PLATFORM_OS }}-${{ steps.set-build-variables.outputs.PLATFORM_ARCH }}
 
-
   process-image-manifest:
     runs-on: ubuntu-latest
     name: process-image-manifest
@@ -106,7 +78,7 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ${{ env.IMAGE_REGISTRY }}
+          registry: ${{ needs.setup.outputs.image_registry }}
       - name: "Append to Bundle Image Manifest"
         shell: bash
         run: |
@@ -115,7 +87,7 @@ jobs:
           if [[ "${{ needs.setup.outputs.image_tag }}" != "latest" ]]; then
             TAGS="$TAGS ${{ needs.setup.outputs.image_tag }}"
           fi
-          
+
           for TAG in $TAGS; do \
             podman manifest create ${{ needs.setup.outputs.image_repository }}:$TAG
             for PLATFORM in ${{ needs.setup.outputs.image_platform_tags }}; do \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,40 +4,13 @@ on:
     branches:
       - main
 
-env:
-  DEFAULT_TAG_VERSION: "latest"
-  BUILD_PLATFORMS: "linux/amd64,linux/arm64"
-  IMAGE_REGISTRY: "ghcr.io"
-
 jobs:
   setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Workflow Variables
-        id: set-variables
-        run: |
-          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
-          echo "IMAGE_REPOSITORY=${{ env.IMAGE_REGISTRY}}/$GITHUB_REPOSITORY" >> $GITHUB_OUTPUT
-
-          # Set versions based on presence of tag
-          if [[ "${{ github.ref }}" =~ ^refs/tags/ ]]; then
-            echo "IMAGE_TAG=$(echo ${GITHUB_REF/refs\/tags\//})" >> $GITHUB_OUTPUT
-          else
-            echo "IMAGE_TAG=${DEFAULT_TAG_VERSION}" >> $GITHUB_OUTPUT
-          fi
-
-          # Create Distribution Matrix
-          echo "DIST_MATRIX=$(echo -n "$BUILD_PLATFORMS" | jq -csR '. | split(",")')" >> $GITHUB_OUTPUT
-          # Create Image Tags
-          echo "IMAGE_PLATFORM_TAGS=$(echo $BUILD_PLATFORMS | sed  -e 's/,/ /g' -e 's/\//-/g')" >> $GITHUB_OUTPUT
-
-    outputs:
-      repository_name: ${{ steps.set-variables.outputs.REPOSITORY_NAME }}
-      image_repository: ${{ steps.set-variables.outputs.IMAGE_REPOSITORY }}
-      image_tag: ${{ steps.set-variables.outputs.IMAGE_TAG}}
-      dist_matrix: ${{ steps.set-variables.outputs.DIST_MATRIX }}
-      image_platform_tags: ${{ steps.set-variables.outputs.IMAGE_PLATFORM_TAGS }}
-
+    uses: ./.github/workflows/setup.yaml
+    with:
+      default_tag_version: "latest"
+      build_platforms: "linux/amd64,linux/arm64"
+      image_registry: "ghcr.io"
 
   build:
     runs-on: ubuntu-latest
@@ -64,7 +37,7 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a #pin@v2.1.0
         with:
-          registry: ${{ env.IMAGE_REGISTRY }}
+          registry: ${{ needs.setup.outputs.image_registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -1,0 +1,58 @@
+name: Setup Workflow Variables
+
+on:
+  workflow_call:
+    inputs:
+      default_tag_version:
+        required: true
+        type: string
+      build_platforms:
+        required: true
+        type: string
+      image_registry:
+        required: true
+        type: string
+    outputs:
+      repository_name:
+        value: ${{ jobs.setup.outputs.repository_name }}
+      image_repository:
+        value: ${{ jobs.setup.outputs.image_repository }}
+      image_registry:
+        value: ${{ jobs.setup.outputs.image_registry }}
+      image_tag:
+        value: ${{ jobs.setup.outputs.image_tag }}
+      dist_matrix:
+        value: ${{ jobs.setup.outputs.dist_matrix }}
+      image_platform_tags:
+        value: ${{ jobs.setup.outputs.image_platform_tags }}
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Workflow Variables
+        id: set-variables
+        run: |
+          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
+          echo "IMAGE_REPOSITORY=${{ inputs.image_registry }}/$GITHUB_REPOSITORY" >> $GITHUB_OUTPUT
+          echo "IMAGE_REGISTRY=${{ inputs.image_registry }}" >> $GITHUB_OUTPUT
+
+          # Set versions based on presence of tag
+          if [[ "${{ github.ref }}" =~ ^refs/tags/ ]]; then
+            echo "IMAGE_TAG=$(echo ${GITHUB_REF/refs\/tags\//})" >> $GITHUB_OUTPUT
+          else
+            echo "IMAGE_TAG=${{ inputs.default_tag_version }}" >> $GITHUB_OUTPUT
+          fi
+
+          # Create Distribution Matrix
+          echo "DIST_MATRIX=$(echo -n "${{ inputs.build_platforms }}" | jq -csR '. | split(",")')" >> $GITHUB_OUTPUT
+          # Create Image Tags
+          echo "IMAGE_PLATFORM_TAGS=$(echo ${{ inputs.build_platforms }} | sed  -e 's/,/ /g' -e 's/\//-/g')" >> $GITHUB_OUTPUT
+
+    outputs:
+      repository_name: ${{ steps.set-variables.outputs.REPOSITORY_NAME }}
+      image_repository: ${{ steps.set-variables.outputs.IMAGE_REPOSITORY }}
+      image_registry: ${{ steps.set-variables.outputs.IMAGE_REGISTRY }}
+      image_tag: ${{ steps.set-variables.outputs.IMAGE_TAG}}
+      dist_matrix: ${{ steps.set-variables.outputs.DIST_MATRIX }}
+      image_platform_tags: ${{ steps.set-variables.outputs.IMAGE_PLATFORM_TAGS }}


### PR DESCRIPTION
Resolves #11 

Create a separate setup workflow that can be reused in other workflows.

I had to remove `env` variables from the build and pr workflows since they don't propagate to a nested workflow. From the [GitHub docs](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations):

>  Any environment variables set in an `env` context defined at the workflow level in the caller workflow are not propagated to the called workflow

I also tried to pass them like this:
```yaml
env:
  DEFAULT_TAG_VERSION: "latest"

default_tag_version: ${{ env.DEFAULT_TAG_VERSION }}
```
but got the following error:
```
The workflow is not valid. .github/workflows/build.yaml (Line: 16, Col: 28): Unrecognized named-value: 'env'. Located at position 1 within expression: env.DEFAULT_TAG_VERSION
```

The best solution I found is to define the parameters in the workflow run arguments.